### PR TITLE
Fix(core): attempt connection in restoreExistingWallet if not connected

### DIFF
--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -45,6 +45,19 @@ const createNewWallet = async (self) => {
 const restoreExistingWallet = async (self, dappShare) => {
   await initWeb3Auth(self, dappShare)
 
+  // If the user is not connected, we need to connect them first before doing the request
+  if (!await isConnected(self)) {
+    // Connect auth 2.0 account with web3Auth
+    await self.web3Auth.connectTo(WALLET_ADAPTERS.OPENLOGIN, {
+      loginProvider: "jwt",
+      extraLoginOptions: {
+        id_token: await self.authProvider.getIdToken(),
+        verifierIdField: "sub", // same as your JWT Verifier ID
+        domain: self.web3AuthConfig.domain,
+      },
+    });
+  }
+
   const seed = await self.web3Auth.provider.request({method: "solanaPrivateKey", params: {}});
   const custodyWallet = self.Wallet()
   await custodyWallet.init(seed)

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -18,19 +18,6 @@ const isConnected = async (self) => {
 const createNewWallet = async (self) => {
   await initWeb3Auth(self, undefined);
 
-  // check if user already exist. If that's the case we don't have to call connectTo
-  if (!await isConnected(self)) {
-    // Connect auth 2.0 account with web3Auth
-    await self.web3Auth.connectTo(WALLET_ADAPTERS.OPENLOGIN, {
-      loginProvider: "jwt",
-      extraLoginOptions: {
-        id_token: await self.authProvider.getIdToken(),
-        verifierIdField: "sub", // same as your JWT Verifier ID
-        domain: self.web3AuthConfig.domain,
-      },
-    });
-  }
-
   const user = await self.web3Auth.getUserInfo();
   const seed = await self.web3Auth.provider.request({method: "solanaPrivateKey", params: {}});
   const custodyWallet = self.Wallet();
@@ -44,19 +31,6 @@ const createNewWallet = async (self) => {
 
 const restoreExistingWallet = async (self, dappShare) => {
   await initWeb3Auth(self, dappShare)
-
-  // If the user is not connected, we need to connect them first before doing the request
-  if (!await isConnected(self)) {
-    // Connect auth 2.0 account with web3Auth
-    await self.web3Auth.connectTo(WALLET_ADAPTERS.OPENLOGIN, {
-      loginProvider: "jwt",
-      extraLoginOptions: {
-        id_token: await self.authProvider.getIdToken(),
-        verifierIdField: "sub", // same as your JWT Verifier ID
-        domain: self.web3AuthConfig.domain,
-      },
-    });
-  }
 
   const seed = await self.web3Auth.provider.request({method: "solanaPrivateKey", params: {}});
   const custodyWallet = self.Wallet()
@@ -112,6 +86,19 @@ const initWeb3Auth = async (self, dappShare) => {
   self.web3Auth.on(ADAPTER_EVENTS.CONNECTING, () => self.onEvent(ADAPTER_EVENTS.CONNECTING));
   self.web3Auth.on(ADAPTER_EVENTS.DISCONNECTED, () => self.onEvent(ADAPTER_EVENTS.DISCONNECTED));
   self.web3Auth.on(ADAPTER_EVENTS.ERRORED, (error) => self.onEvent(ADAPTER_EVENTS.ERRORED, error));
+
+  // check if user is already connected. If that's the case we don't have to call connectTo
+  if (!await isConnected(self)) {
+    // Connect auth 2.0 account with web3Auth
+    await self.web3Auth.connectTo(WALLET_ADAPTERS.OPENLOGIN, {
+      loginProvider: "jwt",
+      extraLoginOptions: {
+        id_token: await self.authProvider.getIdToken(),
+        verifierIdField: "sub", // same as your JWT Verifier ID
+        domain: self.web3AuthConfig.domain,
+      },
+    });
+  }
 }
 
 const bootstrap = async (self) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticketland-io/wallet-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "BUSL-1.1",
   "main": "lib/index.js",
   "author": "Pavlos Polianidis <pavlos@ticketland.io> (https://ticketland.io)",


### PR DESCRIPTION
# Fixes
- Check for `isConnected` and call `web3Auth.connectTo` in `restoreExistingWallet`. If we do not have a `user` in web3Auth (Which means `isConnected` returns false) then the `web3Auth.provider` is `null`. By calling `web3Auth.connectTo`, the user is redirected to the openlogin page for a few seconds and afterwards is considered connected