### PR TITLE
fix(firebase-auth): add missing self param to accessToken

### DIFF
--- a/packages/firebase-auth/lib/index.js
+++ b/packages/firebase-auth/lib/index.js
@@ -41,7 +41,7 @@ const getIdToken = async (self, forceRefresh = true) => {
   return await auth.currentUser.getIdToken(forceRefresh)
 }
 
-const accessToken = async () => {
+const accessToken = async self => {
   const now = Date.now() / 1000
   const token = jwt_decode(auth.currentUser.accessToken)
 


### PR DESCRIPTION
# Fixes
- Add missing `self` param to `accessToken` function